### PR TITLE
Fix Tooltip Border color Item name mode

### DIFF
--- a/src/main/java/dev/ultimatchamp/enhancedtooltips/component/TooltipBorderColorComponent.java
+++ b/src/main/java/dev/ultimatchamp/enhancedtooltips/component/TooltipBorderColorComponent.java
@@ -6,6 +6,8 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Rarity;
 
+import java.util.List;
+
 public class TooltipBorderColorComponent extends TooltipBackgroundComponent {
     private final ItemStack stack;
     private final EnhancedTooltipsConfig config;
@@ -17,10 +19,15 @@ public class TooltipBorderColorComponent extends TooltipBackgroundComponent {
 
     @Override
     protected void renderBorder(DrawContext context, int x, int y, int width, int height, int z, int page) {
-        int startColor = 0xff000000 | TooltipHelper.getItemBorderColor(stack);
-        if (TooltipHelper.getItemBorderColor(stack) == -1) startColor = EnhancedTooltipsConfig.BorderColor.COMMON.getColor().getRGB();
-
+        List<Integer> color = TooltipHelper.getItemBorderColor(stack);
+        int startColor = 0xff000000 | color.get(0);
         int endColor = EnhancedTooltipsConfig.BorderColor.END_COLOR.getColor().getRGB();
+        if (color.get(0) == -1) startColor = EnhancedTooltipsConfig.BorderColor.COMMON.getColor().getRGB();
+
+        if(EnhancedTooltipsConfig.load().border.borderColor == EnhancedTooltipsConfig.BorderColorMode.ITEM_NAME)
+        {
+            endColor = 0xff000000 | color.get(1);
+        }
 
         if (config.border.borderColor == EnhancedTooltipsConfig.BorderColorMode.CUSTOM) {
             if (stack.getRarity() == Rarity.UNCOMMON) {

--- a/src/main/java/dev/ultimatchamp/enhancedtooltips/tooltip/TooltipHelper.java
+++ b/src/main/java/dev/ultimatchamp/enhancedtooltips/tooltip/TooltipHelper.java
@@ -9,6 +9,10 @@ import net.minecraft.text.Text;
 import net.minecraft.text.TextColor;
 import net.minecraft.util.Colors;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class TooltipHelper {
     public static Text getRarityName(ItemStack stack) {
         String key = EnhancedTooltips.MOD_ID + ".rarity." + stack.getRarity().name().toLowerCase();
@@ -25,23 +29,49 @@ public class TooltipHelper {
         *///?}
     }
 
-    public static int getItemBorderColor(ItemStack stack) {
-        Integer color = null;
+    public static List<Integer> getItemBorderColor(ItemStack stack) {
+        List<Integer> color = new ArrayList<>(Arrays.asList(null, null));;
 
         if (EnhancedTooltipsConfig.load().border.borderColor == EnhancedTooltipsConfig.BorderColorMode.ITEM_NAME) {
             Text displayName = getDisplayName(stack);
+            List<Text> outerSiblings = displayName.getSiblings();
 
-            color = TranslationStringColorParser.getColorFromTranslation(displayName);
-
-            TextColor textColor = displayName.getStyle().getColor();
-            if (color == -1 && textColor != null) color = displayName.getStyle().getColor().getRgb();
+            if (outerSiblings != null && !outerSiblings.isEmpty()) {
+                for (Text outerSibling : outerSiblings) {
+                    List<Text> innerSiblings = outerSibling.getSiblings();
+                    if (innerSiblings != null && !innerSiblings.isEmpty()) {
+                        for (Text innerSibling : innerSiblings) {
+                            TextColor siblingColor = innerSibling.getStyle().getColor();
+                            if (siblingColor != null) {
+                                if (color.get(0) == null) {
+                                    color.set(0, siblingColor.getRgb());
+                                }
+                                color.set(1, siblingColor.getRgb());
+                            }
+                        }
+                    }
+                    else {
+                        TextColor siblingColor = outerSibling.getStyle().getColor();
+                        if (siblingColor != null) {
+                            color.set(0, siblingColor.getRgb());
+                            color.set(1, siblingColor.getRgb());
+                            break;
+                        }
+                    }
+                }
+            }
+            if (color.get(0) == null || color.get(0) == -1) {
+                Integer clr = stack.getRarity().getFormatting().getColorValue();
+                color.set(0, clr);
+                color.set(1, clr);
+            }
         }
-
-        if (color == null || color == -1 || color == 0xFFFFFF) {
-            color = stack.getRarity().getFormatting().getColorValue();
-            if (color == null || color == 0xFFFFFF) color = -1;
+        else{
+            if (color.get(0) == null || color.get(0) == -1 || color.get(0) == 0xFFFFFF) {
+                color.set(0, stack.getRarity().getFormatting().getColorValue());
+                if (color.get(0) == null || color.get(0) == 0xFFFFFF) color.set(0, -1);
+            }
         }
-
         return color;
     }
 }


### PR DESCRIPTION
Fixed the display of the border color in the item name mode, as it looks attached in the screenshots. It may not be very good code, but it works.

<img width="350" height="189" alt="изображение_2025-09-06_225645871" src="https://github.com/user-attachments/assets/2edd9dfd-299e-4524-8137-d47f5cbc1987" />
<img width="383" height="175" alt="image" src="https://github.com/user-attachments/assets/bc997ed0-5930-4e80-bab9-e24b3baa5609" />
<img width="428" height="124" alt="image" src="https://github.com/user-attachments/assets/f67487c1-fa3f-40d1-b0b1-630c292daed6" />
